### PR TITLE
Minor correction in 'How to reverse an array'

### DIFF
--- a/doc/source/user/absolute_beginners.rst
+++ b/doc/source/user/absolute_beginners.rst
@@ -1165,7 +1165,7 @@ can reverse the contents of the row at index position 1 (the second row)::
   >>> print(arr_2d)
   Reversed Array:
     [[ 1  2  3  4]
-     [ 5  6  7  8]
+     [ 8  7  6  5]
      [ 9 10 11 12]]
 
 You can also reverse the column at index position 1 (the second column)::
@@ -1176,7 +1176,7 @@ You can also reverse the column at index position 1 (the second column)::
   >>> print(arr_2d)
   Reversed Array:
     [[ 1 10  3  4]
-     [ 5  6  7  8]
+     [ 8  7  6  5]
      [ 9  2 11 12]]
 
 Read more about reversing arrays at `flip`.


### PR DESCRIPTION
DOC: Minor correction in the absolute basics for beginners
Tested in the latest version of numpy. 
The printed output once row `[1]` is flipped was incorrectly shown unchanged.  
This is probably because that code cell was executed twice, unflipping the row :)

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
